### PR TITLE
Fix graphite_keys parsing

### DIFF
--- a/library/Graphite/Grapher.php
+++ b/library/Graphite/Grapher.php
@@ -119,7 +119,7 @@ class Grapher extends GrapherHook
             $this->parseGrapherConfig($object->customvars["graphite"]);
         }
 
-        $this->getKeysAndLabels(array(), $object->customvars);
+        $this->getKeysAndLabels($object->customvars);
         if (empty($this->graphiteKeys)) {
           $this->getPerfDataKeys($object);
         }


### PR DESCRIPTION
Hi,
Ive been having a similar issue to that brought up on ISSUE-33 however the workaround there didn't help.  Turns out instead an errant empty array was confusing the parsing by thinking there wasn't any custom vars.

This fixes the problem for me.  I must admit I'm a novice at PHP so I don't understand if it was put in like that for a specific reason (perhaps only half-completed?).  If that's the case, I'm happy to fix this properly :-)

Thanks
Usman
